### PR TITLE
Adds Kinesis->Lambda module

### DIFF
--- a/modules/lambda-kinesis/main.tf
+++ b/modules/lambda-kinesis/main.tf
@@ -1,0 +1,20 @@
+data "aws_iam_policy_document" "kinesis_policy_document" {
+  statement {
+    actions = "${var.kinesis_actions}"
+    resources = [
+      "${var.kinesis_arn}"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_kinesis_policy" {
+  name = "${var.iam_role_name}"
+  role = "${var.lambda_role_name}"
+  policy = "${data.aws_iam_policy_document.kinesis_policy_document.json}"
+}
+
+resource "aws_lambda_event_source_mapping" "kinesis_to_lambda_mapping" {
+  event_source_arn = "${var.kinesis_arn}"
+  function_name = "${var.lambda_arn}"
+  starting_position = "${var.stream_starting_position}"
+}

--- a/modules/lambda-kinesis/variables.tf
+++ b/modules/lambda-kinesis/variables.tf
@@ -1,0 +1,21 @@
+variable "lambda_arn" {}
+variable "kinesis_arn" {}
+
+variable "iam_role_name" {
+  default = "iam_for_lambda_with_kinesis"
+}
+
+variable "stream_starting_position" {
+  default = "TRIM_HORIZON"
+}
+
+variable "kinesis_actions" {
+  type    = "list"
+  default = [
+    "kinesis:DescribeStream",
+    "kinesis:GetShardIterator",
+    "kinesis:GetRecords",
+    "kinesis:ListStreams",
+    "kinesis:PutRecords",
+  ]
+}

--- a/modules/lambda-kinesis/variables.tf
+++ b/modules/lambda-kinesis/variables.tf
@@ -1,4 +1,5 @@
 variable "lambda_arn" {}
+variable "lambda_role_name" {}
 variable "kinesis_arn" {}
 
 variable "iam_role_name" {


### PR DESCRIPTION
Makes subscribing Lambda functions to Kinesis streams easier by hiding some of the glue.

Usage:
```
# Subscribe Lambda function to Kinesis stream
module "kinesis_to_lambda" {
  source = "github.com/rackerlabs/xplat-terraform-modules/modules/lambda-kinesis"
  lambda_arn = "${module.mylambda.lambda_arn}"
  lambda_role_name = "${module.mylambda.lambda_role_name}"
  kinesis_arn = "${aws_kinesis_stream.mystream.arn}"
}
```