### PR TITLE
Fix alarm_actions to ensure a list is passed

### DIFF
--- a/modules/apigateway/main.tf
+++ b/modules/apigateway/main.tf
@@ -130,7 +130,7 @@ resource "aws_cloudwatch_metric_alarm" "api_5XX" {
         ApiName = "${var.stage}_${var.name}",
         Stage = "${var.stage}"
     }
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = ["${var.alarm_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "api_4XX" {
@@ -149,5 +149,5 @@ resource "aws_cloudwatch_metric_alarm" "api_4XX" {
         ApiName = "${var.stage}_${var.name}",
         Stage = "${var.stage}"
     }
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = ["${var.alarm_actions}"]
 }

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -90,7 +90,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
         FunctionName = "${var.stage}_${var.name}",
         Resource = "${var.stage}_${var.name}:${var.stage}"
     }
-    alarm_actions = "${var.alarm_actions}"
+    alarm_actions = ["${var.alarm_actions}"]
 }
 
 # This is needed for creating the invocation ARN


### PR DESCRIPTION
Because of how variables are passed between modules, we need to be explicit about the nature of `alarm_actions`.