### PR TITLE
Adds lambda-s3 module

### DIFF
--- a/modules/lambda-s3/main.tf
+++ b/modules/lambda-s3/main.tf
@@ -1,0 +1,34 @@
+
+# Subscribe Lambda function to S3 object creation
+resource "aws_lambda_permission" "allow_bucket" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = "${var.lambda_arn}"
+  principal     = "s3.amazonaws.com"
+  source_arn    = "${var.s3_arn}"
+}
+
+# Additional policy to allow S3 access from Lambda
+data "aws_iam_policy_document" "lambda_s3_policy" {
+  statement {
+    actions = "${var.s3_policy_actions}"
+    resources = [
+      "${var.s3_arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "hello_lambda_s3_policy" {
+  name = "${var.lambda_s3_policy_name}"
+  role = "${var.lambda_role_name}"
+  policy = "${data.aws_iam_policy_document.lambda_s3_policy.json}"
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  # Derive bucket name from the arn
+  bucket = "${element(split(":", var.s3_arn), 5)}"
+  lambda_function {
+    lambda_function_arn = "${var.lambda_arn}"
+    events = "${var.s3_events}"
+  }
+}

--- a/modules/lambda-s3/variables.tf
+++ b/modules/lambda-s3/variables.tf
@@ -1,0 +1,16 @@
+variable "lambda_arn" {}
+variable "lambda_role_name" {}
+variable "lambda_s3_policy_name" {}
+variable "s3_arn" {}
+
+# Actions that the Lambda function should be able to take against the S3 bucket
+variable "s3_policy_actions" {
+  type    = "list"
+  default = ["s3:GetObject"]
+}
+
+# S3 events to trigger the Lambda function for
+variable "s3_events" {
+    type = "list"
+    default = ["s3:ObjectCreated:*"]
+}


### PR DESCRIPTION
Quick module to roll up 3 AWS resource calls and a policy data item.

Usage:

```
# Subscribe Lambda function to S3 object creation
module "s3_to_lambda" {
  source = "github.com/rackerlabs/xplat-terraform-modules//modules/lambda-s3"
  lambda_arn = "${module.helloworld_lambda.lambda_arn}"
  lambda_role_name = "${module.helloworld_lambda.lambda_role_name}"
  lambda_s3_policy_name = "${var.stage}_${var.service_name}_lambda_s3"
  s3_arn = "${aws_s3_bucket.helloworld_bucket.arn}"
}
```