### PR TITLE
Add API name and description as template variables

### DIFF
--- a/modules/apigateway/main.tf
+++ b/modules/apigateway/main.tf
@@ -58,6 +58,8 @@ data "template_file" "swagger_file" {
     lambda_arn = "${var.lambda_arn}"
     lambda_role = "${aws_iam_role.api_gateway_invoker.arn}"
     stage = "${var.stage != "prod" ? format("%s-", var.stage) : ""}"
+    api_name = "${var.stage}_${var.name}"
+    description = "${var.description} (stage: ${var.stage})"
   }
 }
 


### PR DESCRIPTION
It seems API Gateway will change the API name and description according to the Swagger file, so if they are not the same as the ones set by the module, it'll get out of sync, and will reverted back on a subsequent `terraform apply`. With these changes, if the Swagger file uses these variables, no unexpected changes would happen.