### PR TITLE
Add hash of swagger file to API Gateway deployment to ensure updates

### DIFF
--- a/modules/apigateway/main.tf
+++ b/modules/apigateway/main.tf
@@ -72,6 +72,11 @@ resource "aws_api_gateway_deployment" "stage" {
 
   rest_api_id = "${aws_api_gateway_rest_api.api.id}"
   stage_name  = "${var.stage}"
+
+  variables = {
+    "version" = "${md5(data.template_file.swagger_file.rendered)}"
+  }
+
 }
 
 data "aws_acm_certificate" "ssl_cert" {


### PR DESCRIPTION
Without this, the deployment resource does not necessarily know that the swagger file has been updated and will not deploy the updated API.