### PR TITLE
Add in support for lambda in vpc.

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -57,6 +57,11 @@ resource "aws_lambda_function" "lambda" {
   runtime          = "${var.runtime}"
   description      = "${var.description} (stage: ${var.stage})"
 
+  vpc_config {
+    subnet_ids         = ["${var.subnet_ids}"]
+    security_group_ids = ["${var.security_group_ids}"]
+  }
+
   environment {
     variables = "${var.env_variables}"
   }

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -48,3 +48,13 @@ variable "description" {
   type    = "string"
   default = ""
 }
+
+variable "subnet_ids" {
+  type    = "list"
+  default = []
+}
+
+variable "security_group_ids" {
+  type    = "list"
+  default = []
+}


### PR DESCRIPTION
Needed for lambda's in Trebutchet that require access to the Rackspace network over the backhaul.

From Terraform documentation:
   if both subnet_ids and security_group_ids are empty then vpc_config is considered to be empty or unset.

Defaults to empty so default behavior is not to use this in the module.  Only activated if vars are set.