### PR TITLE
Revert "Add in support for lambda in vpc."

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -57,11 +57,6 @@ resource "aws_lambda_function" "lambda" {
   runtime          = "${var.runtime}"
   description      = "${var.description} (stage: ${var.stage})"
 
-  vpc_config {
-    subnet_ids         = ["${var.subnet_ids}"]
-    security_group_ids = ["${var.security_group_ids}"]
-  }
-
   environment {
     variables = "${var.env_variables}"
   }

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -48,13 +48,3 @@ variable "description" {
   type    = "string"
   default = ""
 }
-
-variable "subnet_ids" {
-  type    = "list"
-  default = []
-}
-
-variable "security_group_ids" {
-  type    = "list"
-  default = []
-}


### PR DESCRIPTION
Reverts rackerlabs/xplat-terraform-modules#16

Unfortunately, this breaks non-VPC lambdas. Reverting for now while I work on a solution that works for both. 