### PR TITLE
Add Lambda function name and REST API name to module outputs

### DIFF
--- a/modules/apigateway/outputs.tf
+++ b/modules/apigateway/outputs.tf
@@ -2,6 +2,10 @@ output "api_id" {
   value = "${aws_api_gateway_rest_api.api.id}"
 }
 
+output "api_name" {
+  value = "${aws_api_gateway_rest_api.api.name}"
+}
+
 output "invoke_url" {
   # If we have a custom domain set up, we should point the endpoint to that.
   # Otherwise take the deployment's invoke URL, and strip the intermediary

--- a/modules/lambda-in-vpc/outputs.tf
+++ b/modules/lambda-in-vpc/outputs.tf
@@ -13,3 +13,7 @@ output "lambda_arn" {
 output "lambda_alias_arn" {
   value = "${aws_lambda_alias.lambda_alias.arn}"
 }
+
+output "lambda_function_name" {
+  value = "${aws_lambda_function.lambda.function_name}"
+}

--- a/modules/lambda/outputs.tf
+++ b/modules/lambda/outputs.tf
@@ -13,3 +13,7 @@ output "lambda_arn" {
 output "lambda_alias_arn" {
   value = "${aws_lambda_alias.lambda_alias.arn}"
 }
+
+output "lambda_function_name" {
+  value = "${aws_lambda_function.lambda.function_name}"
+}


### PR DESCRIPTION
Some resource attributes expect the `function_name` to be provided (e.g. [Lambda permissions](https://www.terraform.io/docs/providers/aws/r/lambda_permission.html)), which we can parse from the ARN that's already exported, but it's cleaner to have a separate output for it.