### PR TITLE
Use the most recent SSL certificate

### DIFF
--- a/modules/apigateway/main.tf
+++ b/modules/apigateway/main.tf
@@ -83,9 +83,10 @@ resource "aws_api_gateway_deployment" "stage" {
 data "aws_acm_certificate" "ssl_cert" {
   count = "${var.enable_custom_domain}"
 
-  provider = "aws.us-east-1"     # Set the us-east-1 provider from above.
-  domain   = "${var.ssl_domain}"
-  statuses = ["ISSUED"]
+  provider    = "aws.us-east-1"     # Set the us-east-1 provider from above.
+  domain      = "${var.ssl_domain}"
+  statuses    = ["ISSUED"]
+  most_recent = true
 }
 
 resource "aws_api_gateway_domain_name" "domain" {


### PR DESCRIPTION
This should fix those cases where we have multiple valid certificates available.