### PR TITLE
Pass along the authorizer type to the Swagger template

### DIFF
--- a/modules/apigateway/main.tf
+++ b/modules/apigateway/main.tf
@@ -48,6 +48,7 @@ data "template_file" "swagger_file" {
   template = "${var.swagger_template}"
 
   vars {
+    authorizer_type       = "${var.authorizer_type}"
     authorizer_arn        = "${var.authorizer_arn}"
     authorizer_header     = "${var.authorizer_header}"
     authorizer_role       = "${aws_iam_role.api_gateway_invoker.arn}"

--- a/modules/apigateway/variables.tf
+++ b/modules/apigateway/variables.tf
@@ -23,6 +23,11 @@ variable "authorizer_ttl" {
   default = ""
 }
 
+variable "authorizer_type" {
+  type    = "string"
+  default = "token"
+}
+
 variable "base_path" {
   type    = "string"
   default = ""


### PR DESCRIPTION
This way we could also use `request` type custom authorizers.