### PR TITLE
Adds module which puts SQS queue in front of a lambda

### DIFF
--- a/modules/lambda-sqs-sns/README.md
+++ b/modules/lambda-sqs-sns/README.md
@@ -1,0 +1,17 @@
+# lambda-sqs-sns
+
+Puts an SQS queue between an SNS topic and a lambda.
+
+Use this if you would otherwise have a lambda consuming from an SNS topic but don't want to risk losing any messages.
+
+The SQS queue will instead consume messages from the SNS topic and then automatically deliver them to the lambda. If the lambda fails to process them, they will be sent to a dead letter queue which is also created by this module.
+
+## Variables
+
+* sns_arn - The SNS topic you want to read messages from.
+
+* lambda_arn - The lambda you want to direct messages to.
+
+* name - Used, along with `stage`, to create the name of the main queue and the dead letter queue. Also used for some tags.
+
+* stage - See `name`.

--- a/modules/lambda-sqs-sns/main.tf
+++ b/modules/lambda-sqs-sns/main.tf
@@ -1,0 +1,84 @@
+# # Set up SQS --------------------------------------------------------------
+
+# SQS dead letter queue
+resource "aws_sqs_queue" "dead_letter_queue" {
+  name                       = "${var.stage}_${var.name}_dead_letter_queue"
+  visibility_timeout_seconds = 120
+
+  tags {
+    stage   = "${var.stage}"
+    service = "${var.name}"
+  }
+}
+
+# The actual queue the Lambda will listen to
+resource "aws_sqs_queue" "queue" {
+  name           = "${var.stage}_${var.name}_queue"
+  redrive_policy = "{\"deadLetterTargetArn\":\"${aws_sqs_queue.dead_letter_queue.arn}\",\"maxReceiveCount\":4}"
+
+  visibility_timeout_seconds = 120
+
+  tags {
+    stage   = "${var.stage}"
+    service = "${var.name}"
+  }
+}
+
+# Give permissions to SNS to send to SQS
+data "aws_iam_policy_document" "sqs_write_policy" {
+  statement {
+    sid = "AllowLocalWrites"
+
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    resources = ["${aws_sqs_queue.queue.arn}"]
+
+    principals {
+      identifiers = ["sns.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+
+  statement {
+    sid = "AllowSNSWrites"
+
+    actions = [
+      "sqs:SendMessage",
+    ]
+
+    resources = ["${aws_sqs_queue.queue.arn}"]
+
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+
+    condition {
+      test     = "ArnEquals"
+      values   = ["${var.sns_arn}"]
+      variable = "aws:SourceArn"
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "queue_policy" {
+  policy    = "${data.aws_iam_policy_document.sqs_write_policy.json}"
+  queue_url = "${aws_sqs_queue.queue.id}"
+}
+
+# hook up SNS --> SQS
+resource "aws_sns_topic_subscription" "sns_to_sqs" {
+  topic_arn = "${var.sns_arn}"
+  protocol  = "sqs"
+  endpoint  = "${aws_sqs_queue.queue.arn}"
+}
+
+# hook up SQS to the Lambda
+resource "aws_lambda_event_source_mapping" "event_source_mapping" {
+  batch_size       = 5
+  event_source_arn = "${aws_sqs_queue.queue.arn}"
+  enabled          = true
+  function_name    = "${var.lambda_arn}"
+}

--- a/modules/lambda-sqs-sns/variables.tf
+++ b/modules/lambda-sqs-sns/variables.tf
@@ -1,0 +1,10 @@
+# What is this called
+variable "name" {}
+
+variable "stage" {}
+
+# Incoming Lambda to hook up to SQS, which itself will be hooked up to SNS
+variable "lambda_arn" {}
+
+# An SNS topic
+variable "sns_arn" {}


### PR DESCRIPTION
This adds a module which inserts an SQS queue between an SNS topic and
a lambda. The result is similar to when a lambda reads from SNS, but
the risk of losing messages is mitigated as they're first sent to SQS
and can be put in a dead letter queue on failure.