### PR TITLE
Remove lambda:InvokeFunction permissions from Lambda policies

### DIFF
--- a/modules/lambda-in-vpc/main.tf
+++ b/modules/lambda-in-vpc/main.tf
@@ -25,7 +25,6 @@ data "aws_iam_policy_document" "base_lambda_policy" {
       "ec2:DescribeNetworkInterfaces",
       "ec2:DeleteNetworkInterface",
       "logs:*",
-      "lambda:InvokeFunction",
       "xray:PutTraceSegments",
       "xray:PutTelemetryRecords",
     ]

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -22,7 +22,6 @@ data "aws_iam_policy_document" "base_lambda_policy" {
   statement {
     actions = [
       "logs:*",
-      "lambda:InvokeFunction",
       "xray:PutTraceSegments",
       "xray:PutTelemetryRecords",
     ]


### PR DESCRIPTION
In the spirit of least privilege principles, Lambda functions should not be able to invoke other Lambda functions out of the box (especially not any of them).