### PR TITLE
Region resource no longer requires current arg

### DIFF
--- a/modules/lambda-in-vpc/main.tf
+++ b/modules/lambda-in-vpc/main.tf
@@ -117,9 +117,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
 }
 
 # This is needed for creating the invocation ARN
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 output "api_invocation_arn" {
   value = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_alias.lambda_alias.arn}/invocations"

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -110,9 +110,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
 }
 
 # This is needed for creating the invocation ARN
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}
 
 output "api_invocation_arn" {
   value = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_alias.lambda_alias.arn}/invocations"


### PR DESCRIPTION
https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#current-argument-removal

Leaving this in now produces an error which fails the `plan` step.