### PR TITLE
Adds lambda module that uses code in S3

### DIFF
--- a/modules/lambda-in-vpc-with-s3/main.tf
+++ b/modules/lambda-in-vpc-with-s3/main.tf
@@ -1,0 +1,125 @@
+# IAM
+# Base AssumeRole policy for Lambda execution.
+data "aws_iam_policy_document" "execution_lambda_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "lambda.amazonaws.com",
+        "apigateway.amazonaws.com",
+      ]
+    }
+  }
+}
+
+# Base policy for Lambda to execute.
+data "aws_iam_policy_document" "base_lambda_policy" {
+  statement {
+    actions = [
+      "ec2:CreateNetworkInterface",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DeleteNetworkInterface",
+      "logs:*",
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+# Create Lambda role with AssumeRole policy.
+resource "aws_iam_role" "execution_lambda_role" {
+  name               = "${var.stage}_${var.name}_lambda"
+  assume_role_policy = "${data.aws_iam_policy_document.execution_lambda_policy.json}"
+}
+
+# Attach base policy to Lambda role
+resource "aws_iam_role_policy" "base_lambda_policy" {
+  name   = "${var.stage}_${var.name}_lambda_policy"
+  role   = "${aws_iam_role.execution_lambda_role.id}"
+  policy = "${data.aws_iam_policy_document.base_lambda_policy.json}"
+}
+
+# Lambda
+resource "aws_lambda_function" "lambda" {
+  function_name    = "${var.stage}_${var.name}"
+  s3_bucket        = "${var.s3_bucket}"
+  s3_key           = "${var.s3_key}"
+  role             = "${aws_iam_role.execution_lambda_role.arn}"
+  handler          = "${var.handler}"
+  memory_size      = "${var.memory_size}"
+  timeout          = "${var.timeout}"
+  publish          = "${var.publish}"
+  source_code_hash = "${var.source_code_hash}"
+  runtime          = "${var.runtime}"
+  description      = "${var.description} (stage: ${var.stage})"
+  tags             = "${var.tags}"
+
+  tracing_config {
+    mode = "${var.tracing_mode}"
+  }
+
+  vpc_config {
+    subnet_ids         = ["${var.subnet_ids}"]
+    security_group_ids = ["${var.security_group_ids}"]
+  }
+
+  environment {
+    variables = "${var.env_variables}"
+  }
+}
+
+# Temporary work-around for https://github.com/terraform-providers/terraform-provider-aws/issues/626 -
+# aws_lambda_alias uses previous version number.
+data "template_file" "function_version" {
+  template = "$${function_version}"
+
+  vars {
+    function_version = "${aws_lambda_function.lambda.version}"
+  }
+
+  depends_on = ["aws_lambda_function.lambda"]
+}
+
+resource "aws_lambda_alias" "lambda_alias" {
+  name             = "${var.stage}"
+  function_name    = "${aws_lambda_function.lambda.arn}"
+  function_version = "${data.template_file.function_version.rendered}"
+
+  depends_on = ["aws_lambda_function.lambda", "data.template_file.function_version"]
+}
+
+# Cloudwatch
+resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
+  count                     = "${var.enable_monitoring}"                  # Only create on certain stages.
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  metric_name               = "Throttles"
+  namespace                 = "AWS/Lambda"
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
+  insufficient_data_actions = []
+
+  dimensions {
+    FunctionName = "${var.stage}_${var.name}"
+    Resource     = "${var.stage}_${var.name}:${var.stage}"
+  }
+
+  alarm_actions = ["${var.alarm_actions}"]
+}
+
+# This is needed for creating the invocation ARN
+data "aws_region" "current" {}
+
+output "api_invocation_arn" {
+  value = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_alias.lambda_alias.arn}/invocations"
+}

--- a/modules/lambda-in-vpc-with-s3/outputs.tf
+++ b/modules/lambda-in-vpc-with-s3/outputs.tf
@@ -1,0 +1,19 @@
+output "lambda_role_name" {
+  value = "${aws_iam_role.execution_lambda_role.name}"
+}
+
+output "lambda_role_arn" {
+  value = "${aws_iam_role.execution_lambda_role.arn}"
+}
+
+output "lambda_arn" {
+  value = "${aws_lambda_function.lambda.arn}"
+}
+
+output "lambda_alias_arn" {
+  value = "${aws_lambda_alias.lambda_alias.arn}"
+}
+
+output "lambda_function_name" {
+  value = "${aws_lambda_function.lambda.function_name}"
+}

--- a/modules/lambda-in-vpc-with-s3/variables.tf
+++ b/modules/lambda-in-vpc-with-s3/variables.tf
@@ -1,0 +1,73 @@
+variable "alarm_actions" {
+  type    = "list"
+  default = []
+}
+
+variable "enable_monitoring" {
+  type    = "string"
+  default = 0
+}
+
+variable "env_variables" {
+  type    = "map"
+  default = {}
+}
+
+variable "source_code_hash" {}
+
+variable "s3_bucket" {}
+variable "s3_key" {}
+
+variable "handler" {
+  type    = "string"
+  default = "handler.lambda_handler"
+}
+
+variable "memory_size" {
+  type    = "string"
+  default = 256
+}
+
+variable "name" {}
+
+variable "publish" {
+  type    = "string"
+  default = true
+}
+
+variable "stage" {}
+
+variable "runtime" {
+  type    = "string"
+  default = "python3.6"
+}
+
+variable "timeout" {
+  type    = "string"
+  default = 60
+}
+
+variable "description" {
+  type    = "string"
+  default = ""
+}
+
+variable "subnet_ids" {
+  type    = "list"
+  default = []
+}
+
+variable "security_group_ids" {
+  type    = "list"
+  default = []
+}
+
+variable "tracing_mode" {
+  type    = "string"
+  default = "PassThrough"
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}

--- a/modules/lambda-with-s3/main.tf
+++ b/modules/lambda-with-s3/main.tf
@@ -1,0 +1,118 @@
+# IAM
+# Base AssumeRole policy for Lambda execution.
+data "aws_iam_policy_document" "execution_lambda_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "lambda.amazonaws.com",
+        "apigateway.amazonaws.com",
+      ]
+    }
+  }
+}
+
+# Base policy for Lambda to execute.
+data "aws_iam_policy_document" "base_lambda_policy" {
+  statement {
+    actions = [
+      "logs:*",
+      "lambda:InvokeFunction",
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+# Create Lambda role with AssumeRole policy.
+resource "aws_iam_role" "execution_lambda_role" {
+  name               = "${var.stage}_${var.name}_lambda"
+  assume_role_policy = "${data.aws_iam_policy_document.execution_lambda_policy.json}"
+}
+
+# Attach base policy to Lambda role
+resource "aws_iam_role_policy" "base_lambda_policy" {
+  name   = "${var.stage}_${var.name}_lambda_policy"
+  role   = "${aws_iam_role.execution_lambda_role.id}"
+  policy = "${data.aws_iam_policy_document.base_lambda_policy.json}"
+}
+
+# Lambda
+resource "aws_lambda_function" "lambda" {
+  function_name    = "${var.stage}_${var.name}"
+  s3_bucket        = "${var.s3_bucket}"
+  s3_key           = "${var.s3_key}"
+  role             = "${aws_iam_role.execution_lambda_role.arn}"
+  handler          = "${var.handler}"
+  memory_size      = "${var.memory_size}"
+  timeout          = "${var.timeout}"
+  publish          = "${var.publish}"
+  source_code_hash = "${var.source_code_hash}"
+  runtime          = "${var.runtime}"
+  description      = "${var.description} (stage: ${var.stage})"
+  kms_key_arn      = "${var.kms_key_arn}"
+
+  tracing_config {
+    mode = "${var.tracing_mode}"
+  }
+
+  environment {
+    variables = "${var.env_variables}"
+  }
+}
+
+# Temporary work-around for https://github.com/terraform-providers/terraform-provider-aws/issues/626 -
+# aws_lambda_alias uses previous version number.
+data "template_file" "function_version" {
+  template = "$${function_version}"
+
+  vars {
+    function_version = "${aws_lambda_function.lambda.version}"
+  }
+
+  depends_on = ["aws_lambda_function.lambda"]
+}
+
+resource "aws_lambda_alias" "lambda_alias" {
+  name             = "${var.stage}"
+  function_name    = "${aws_lambda_function.lambda.arn}"
+  function_version = "${data.template_file.function_version.rendered}"
+
+  depends_on = ["aws_lambda_function.lambda", "data.template_file.function_version"]
+}
+
+# Cloudwatch
+resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
+  count                     = "${var.enable_monitoring}"                  # Only create on certain stages.
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "2"
+  metric_name               = "Throttles"
+  namespace                 = "AWS/Lambda"
+  period                    = "300"
+  statistic                 = "Sum"
+  threshold                 = "1"
+  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
+  insufficient_data_actions = []
+
+  dimensions {
+    FunctionName = "${var.stage}_${var.name}"
+    Resource     = "${var.stage}_${var.name}:${var.stage}"
+  }
+
+  alarm_actions = ["${var.alarm_actions}"]
+}
+
+# This is needed for creating the invocation ARN
+data "aws_region" "current" {}
+
+output "api_invocation_arn" {
+  value = "arn:aws:apigateway:${data.aws_region.current.name}:lambda:path/2015-03-31/functions/${aws_lambda_alias.lambda_alias.arn}/invocations"
+}

--- a/modules/lambda-with-s3/outputs.tf
+++ b/modules/lambda-with-s3/outputs.tf
@@ -1,0 +1,19 @@
+output "lambda_role_name" {
+  value = "${aws_iam_role.execution_lambda_role.name}"
+}
+
+output "lambda_role_arn" {
+  value = "${aws_iam_role.execution_lambda_role.arn}"
+}
+
+output "lambda_arn" {
+  value = "${aws_lambda_function.lambda.arn}"
+}
+
+output "lambda_alias_arn" {
+  value = "${aws_lambda_alias.lambda_alias.arn}"
+}
+
+output "lambda_function_name" {
+  value = "${aws_lambda_function.lambda.function_name}"
+}

--- a/modules/lambda-with-s3/variables.tf
+++ b/modules/lambda-with-s3/variables.tf
@@ -1,0 +1,63 @@
+variable "alarm_actions" {
+  type    = "list"
+  default = []
+}
+
+variable "enable_monitoring" {
+  type    = "string"
+  default = 0
+}
+
+variable "env_variables" {
+  type    = "map"
+  default = {}
+}
+
+variable "source_code_hash" {}
+
+variable "s3_bucket" {}
+variable "s3_key" {}
+
+variable "handler" {
+  type    = "string"
+  default = "handler.lambda_handler"
+}
+
+variable "memory_size" {
+  type    = "string"
+  default = 256
+}
+
+variable "name" {}
+
+variable "publish" {
+  type    = "string"
+  default = true
+}
+
+variable "stage" {}
+
+variable "runtime" {
+  type    = "string"
+  default = "python3.6"
+}
+
+variable "timeout" {
+  type    = "string"
+  default = 60
+}
+
+variable "description" {
+  type    = "string"
+  default = ""
+}
+
+variable "kms_key_arn" {
+  type    = "string"
+  default = ""
+}
+
+variable "tracing_mode" {
+  type    = "string"
+  default = "PassThrough"
+}


### PR DESCRIPTION
For months now many projects have been using Lambdas where the code is
located in s3 versus AWS's built in Lambda storage. There's two HUGE
benefits to this:

* we don't hit limits on the amount of code we're storing
* Terraform runs *far* faster as it isn't necessary to upload the same
  lambda zip file multiple times when all that changes is the handler
  module.

I wanted to built the S3 functionality into the existing lambda modules,
but that is sadly not possible due to the fact Terraform lacks a true
way to define "null" even though it must use such a mechanism
internally. When the "aws_lambda_function" resource is defined, it can
either set the `s3_bucket` and `s3_key` fields or the `filename` field,
but not both. To make a module that would support either approach, we'd
need to be able to pass `null` or something to the fields we aren't
using but `null` isn't going to be a thing until Terraform 0.12 is out.
Even then I'm not positive it will fix this problem.

I've been waiting for months for Terraform 0.12 to come out and during
that time I've copied the "s3" versions of the Lambda module to several
repos. Since it's such a drastic improvement I think we should just
give in and make a new module here instead.