### PR TITLE
Few monitoring related improvements

### DIFF
--- a/modules/lambda-in-vpc-with-s3/main.tf
+++ b/modules/lambda-in-vpc-with-s3/main.tf
@@ -95,10 +95,12 @@ resource "aws_lambda_alias" "lambda_alias" {
   depends_on = ["aws_lambda_function.lambda", "data.template_file.function_version"]
 }
 
-# Cloudwatch
+# CloudWatch Alarms
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  count = "${var.enable_monitoring}" # Only create on certain stages.
+
+  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
   alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
-  count                     = "${var.enable_monitoring}"                  # Only create on certain stages.
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "Throttles"
@@ -106,8 +108,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   period                    = "300"
   statistic                 = "Sum"
   threshold                 = "1"
-  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
-  insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions {
     FunctionName = "${var.stage}_${var.name}"
@@ -115,6 +116,31 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.alarm_actions}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  count = "${var.enable_monitoring}" # Only create on certain stages.
+
+  alarm_description   = "${var.stage} ${var.name} Lambda Errors"
+  alarm_name          = "${var.stage}_${var.service_name}_lambda_errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm = "1"
+  evaluation_periods  = "2"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
+
+  dimensions {
+    FunctionName = "${var.stage}_${var.name}"
+    Resource     = "${var.stage}_${var.name}:${var.stage}"
+  }
+
+  alarm_actions = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.alarm_actions}"]
 }
 
 # This is needed for creating the invocation ARN

--- a/modules/lambda-in-vpc-with-s3/main.tf
+++ b/modules/lambda-in-vpc-with-s3/main.tf
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
   alarm_description   = "${var.stage} ${var.name} Lambda Errors"
-  alarm_name          = "${var.stage}_${var.service_name}_lambda_errors"
+  alarm_name          = "${var.stage}_${var.name}_lambda_errors"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   datapoints_to_alarm = "1"
   evaluation_periods  = "2"

--- a/modules/lambda-in-vpc-with-s3/main.tf
+++ b/modules/lambda-in-vpc-with-s3/main.tf
@@ -116,7 +116,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
@@ -140,7 +140,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 # This is needed for creating the invocation ARN

--- a/modules/lambda-in-vpc-with-s3/variables.tf
+++ b/modules/lambda-in-vpc-with-s3/variables.tf
@@ -3,6 +3,11 @@ variable "alarm_actions" {
   default = []
 }
 
+variable "ok_actions" {
+  type    = "list"
+  default = []
+}
+
 variable "enable_monitoring" {
   type    = "string"
   default = 0

--- a/modules/lambda-in-vpc/main.tf
+++ b/modules/lambda-in-vpc/main.tf
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
   alarm_description   = "${var.stage} ${var.name} Lambda Errors"
-  alarm_name          = "${var.stage}_${var.service_name}_lambda_errors"
+  alarm_name          = "${var.stage}_${var.name}_lambda_errors"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   datapoints_to_alarm = "1"
   evaluation_periods  = "2"

--- a/modules/lambda-in-vpc/main.tf
+++ b/modules/lambda-in-vpc/main.tf
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
@@ -139,7 +139,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 # This is needed for creating the invocation ARN

--- a/modules/lambda-in-vpc/variables.tf
+++ b/modules/lambda-in-vpc/variables.tf
@@ -3,6 +3,11 @@ variable "alarm_actions" {
   default = []
 }
 
+variable "ok_actions" {
+  type    = "list"
+  default = []
+}
+
 variable "enable_monitoring" {
   type    = "string"
   default = 0

--- a/modules/lambda-sqs-sns/README.md
+++ b/modules/lambda-sqs-sns/README.md
@@ -8,14 +8,14 @@ The SQS queue will instead consume messages from the SNS topic and then automati
 
 ## Variables
 
-* sns_arn - The SNS topic you want to read messages from.
+* `sns_arn` - The SNS topic you want to read messages from.
 
-* lambda_arn - The lambda you want to direct messages to.
+* `lambda_arn` - The lambda you want to direct messages to.
 
-* name - Used, along with `stage`, to create the name of the main queue and the dead letter queue. Also used for some tags.
+* `name` - Used, along with `stage`, to create the name of the main queue and the dead letter queue. Also used for some tags.
 
-* stage - See `name`.
+* `stage` - See `name`.
 
-* enable_monitoring - Probably want to set this to `1` in a `prod` environment, so that you get alerted when something hits the DLQ.
+* `enable_monitoring` - Probably want to set this to `1` in a `prod` environment, so that you get alerted when something hits the DLQ.
 
-* alarm_actions - List of SNS topic ARNs and/or email addresses where the alarm should be sent to.
+* `alarm_actions` - List of SNS topic ARNs and/or email addresses where the alarm should be sent to. If you want the alerts to be resolved automatically, you can also set `ok_actions`

--- a/modules/lambda-sqs-sns/README.md
+++ b/modules/lambda-sqs-sns/README.md
@@ -15,3 +15,7 @@ The SQS queue will instead consume messages from the SNS topic and then automati
 * name - Used, along with `stage`, to create the name of the main queue and the dead letter queue. Also used for some tags.
 
 * stage - See `name`.
+
+* enable_monitoring - Probably want to set this to `1` in a `prod` environment, so that you get alerted when something hits the DLQ.
+
+* alarm_actions - List of SNS topic ARNs and/or email addresses where the alarm should be sent to.

--- a/modules/lambda-sqs-sns/main.tf
+++ b/modules/lambda-sqs-sns/main.tf
@@ -105,5 +105,5 @@ resource "aws_cloudwatch_metric_alarm" "dlq_queue_size" {
 
   alarm_actions             = ["${var.alarm_actions}"]
   insufficient_data_actions = []
-  ok_actions                = ["${var.alarm_actions}"]
+  ok_actions                = ["${var.ok_actions}"]
 }

--- a/modules/lambda-sqs-sns/variables.tf
+++ b/modules/lambda-sqs-sns/variables.tf
@@ -13,3 +13,15 @@ variable "sns_arn" {}
 variable "visibility_timeout_seconds" {
   default = 120
 }
+
+variable "enable_monitoring" {
+  type    = "string"
+  default = 0
+}
+
+# List of SNS topic ARNs and/or email addresses
+variable "alarm_actions" {
+  type    = "list"
+  default = []
+}
+

--- a/modules/lambda-sqs-sns/variables.tf
+++ b/modules/lambda-sqs-sns/variables.tf
@@ -25,3 +25,8 @@ variable "alarm_actions" {
   default = []
 }
 
+# If you want the alerts to auto-clear, use this as well
+variable "ok_actions" {
+  type    = "list"
+  default = []
+}

--- a/modules/lambda-with-s3/main.tf
+++ b/modules/lambda-with-s3/main.tf
@@ -109,7 +109,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
@@ -133,7 +133,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 # This is needed for creating the invocation ARN

--- a/modules/lambda-with-s3/main.tf
+++ b/modules/lambda-with-s3/main.tf
@@ -88,10 +88,12 @@ resource "aws_lambda_alias" "lambda_alias" {
   depends_on = ["aws_lambda_function.lambda", "data.template_file.function_version"]
 }
 
-# Cloudwatch
+# CloudWatch Alarms
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  count = "${var.enable_monitoring}" # Only create on certain stages.
+
+  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
   alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
-  count                     = "${var.enable_monitoring}"                  # Only create on certain stages.
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "Throttles"
@@ -99,8 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   period                    = "300"
   statistic                 = "Sum"
   threshold                 = "1"
-  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
-  insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions {
     FunctionName = "${var.stage}_${var.name}"
@@ -108,6 +109,31 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.alarm_actions}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  count = "${var.enable_monitoring}" # Only create on certain stages.
+
+  alarm_description   = "${var.stage} ${var.name} Lambda Errors"
+  alarm_name          = "${var.stage}_${var.service_name}_lambda_errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm = "1"
+  evaluation_periods  = "2"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
+
+  dimensions {
+    FunctionName = "${var.stage}_${var.name}"
+    Resource     = "${var.stage}_${var.name}:${var.stage}"
+  }
+
+  alarm_actions = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.alarm_actions}"]
 }
 
 # This is needed for creating the invocation ARN

--- a/modules/lambda-with-s3/main.tf
+++ b/modules/lambda-with-s3/main.tf
@@ -116,7 +116,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
   alarm_description   = "${var.stage} ${var.name} Lambda Errors"
-  alarm_name          = "${var.stage}_${var.service_name}_lambda_errors"
+  alarm_name          = "${var.stage}_${var.name}_lambda_errors"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   datapoints_to_alarm = "1"
   evaluation_periods  = "2"

--- a/modules/lambda-with-s3/variables.tf
+++ b/modules/lambda-with-s3/variables.tf
@@ -3,6 +3,11 @@ variable "alarm_actions" {
   default = []
 }
 
+variable "ok_actions" {
+  type    = "list"
+  default = []
+}
+
 variable "enable_monitoring" {
   type    = "string"
   default = 0

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
   alarm_description   = "${var.stage} ${var.name} Lambda Errors"
-  alarm_name          = "${var.stage}_${var.service_name}_lambda_errors"
+  alarm_name          = "${var.stage}_${var.name}_lambda_errors"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   datapoints_to_alarm = "1"
   evaluation_periods  = "2"

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -87,10 +87,12 @@ resource "aws_lambda_alias" "lambda_alias" {
   depends_on = ["aws_lambda_function.lambda", "data.template_file.function_version"]
 }
 
-# Cloudwatch
+# CloudWatch Alarms
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
+  count = "${var.enable_monitoring}" # Only create on certain stages.
+
+  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
   alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
-  count                     = "${var.enable_monitoring}"                  # Only create on certain stages.
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = "2"
   metric_name               = "Throttles"
@@ -98,8 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   period                    = "300"
   statistic                 = "Sum"
   threshold                 = "1"
-  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
-  insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions {
     FunctionName = "${var.stage}_${var.name}"
@@ -107,6 +108,31 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.alarm_actions}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
+  count = "${var.enable_monitoring}" # Only create on certain stages.
+
+  alarm_description   = "${var.stage} ${var.name} Lambda Errors"
+  alarm_name          = "${var.stage}_${var.service_name}_lambda_errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm = "1"
+  evaluation_periods  = "2"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
+
+  dimensions {
+    FunctionName = "${var.stage}_${var.name}"
+    Resource     = "${var.stage}_${var.name}:${var.stage}"
+  }
+
+  alarm_actions = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.alarm_actions}"]
 }
 
 # This is needed for creating the invocation ARN

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -108,7 +108,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
@@ -132,7 +132,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   }
 
   alarm_actions = ["${var.alarm_actions}"]
-  ok_actions    = ["${var.alarm_actions}"]
+  ok_actions    = ["${var.ok_actions}"]
 }
 
 # This is needed for creating the invocation ARN

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -3,6 +3,11 @@ variable "alarm_actions" {
   default = []
 }
 
+variable "ok_actions" {
+  type    = "list"
+  default = []
+}
+
 variable "enable_monitoring" {
   type    = "string"
   default = 0


### PR DESCRIPTION
* Set up an alarm for the Lambda errors as well when enabled
* Optionally set up an alarm for the DLQ size in the `lambda-sqs-sns` module
* ~Set `ok_actions` across the board to allow alarms to clear automatically (not 100% convinced this is a good idea, so please let me know if you disagree)~ `ok_actions` is now optional, can be set via the variables, if auto-resolve is needed.
* Also added `treat_missing_data = "notBreaching"`, so that things are nice and green when there are no issues (or no traffic)