### PR TITLE
Allow Lambda concurrency limit to be set

### DIFF
--- a/modules/lambda-in-vpc-with-s3/main.tf
+++ b/modules/lambda-in-vpc-with-s3/main.tf
@@ -48,18 +48,20 @@ resource "aws_iam_role_policy" "base_lambda_policy" {
 
 # Lambda
 resource "aws_lambda_function" "lambda" {
-  function_name    = "${var.stage}_${var.name}"
-  s3_bucket        = "${var.s3_bucket}"
-  s3_key           = "${var.s3_key}"
-  role             = "${aws_iam_role.execution_lambda_role.arn}"
-  handler          = "${var.handler}"
-  memory_size      = "${var.memory_size}"
-  timeout          = "${var.timeout}"
-  publish          = "${var.publish}"
-  source_code_hash = "${var.source_code_hash}"
-  runtime          = "${var.runtime}"
-  description      = "${var.description} (stage: ${var.stage})"
-  tags             = "${var.tags}"
+  function_name                  = "${var.stage}_${var.name}"
+  s3_bucket                      = "${var.s3_bucket}"
+  s3_key                         = "${var.s3_key}"
+  role                           = "${aws_iam_role.execution_lambda_role.arn}"
+  handler                        = "${var.handler}"
+  memory_size                    = "${var.memory_size}"
+  timeout                        = "${var.timeout}"
+  publish                        = "${var.publish}"
+  source_code_hash               = "${var.source_code_hash}"
+  runtime                        = "${var.runtime}"
+  description                    = "${var.description} (stage: ${var.stage})"
+  kms_key_arn                    = "${var.kms_key_arn}"
+  tags                           = "${var.tags}"
+  reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
 
   tracing_config {
     mode = "${var.tracing_mode}"
@@ -99,16 +101,16 @@ resource "aws_lambda_alias" "lambda_alias" {
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
-  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
-  alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  metric_name               = "Throttles"
-  namespace                 = "AWS/Lambda"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  treat_missing_data        = "notBreaching"
+  alarm_description   = "${var.stage} ${var.name} Lambda Throttles"
+  alarm_name          = "${var.stage}_${var.name}_lambda_throttles"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
 
   dimensions {
     FunctionName = "${var.stage}_${var.name}"

--- a/modules/lambda-in-vpc-with-s3/variables.tf
+++ b/modules/lambda-in-vpc-with-s3/variables.tf
@@ -67,6 +67,11 @@ variable "security_group_ids" {
   default = []
 }
 
+variable "kms_key_arn" {
+  type    = "string"
+  default = ""
+}
+
 variable "tracing_mode" {
   type    = "string"
   default = "PassThrough"
@@ -75,4 +80,9 @@ variable "tracing_mode" {
 variable "tags" {
   type    = "map"
   default = {}
+}
+
+variable "reserved_concurrent_executions" {
+  type    = "string"
+  default = "-1"
 }

--- a/modules/lambda-in-vpc/main.tf
+++ b/modules/lambda-in-vpc/main.tf
@@ -48,17 +48,19 @@ resource "aws_iam_role_policy" "base_lambda_policy" {
 
 # Lambda
 resource "aws_lambda_function" "lambda" {
-  function_name    = "${var.stage}_${var.name}"
-  filename         = "${var.file}"
-  role             = "${aws_iam_role.execution_lambda_role.arn}"
-  handler          = "${var.handler}"
-  memory_size      = "${var.memory_size}"
-  timeout          = "${var.timeout}"
-  publish          = "${var.publish}"
-  source_code_hash = "${base64sha256(file("${var.file}"))}"
-  runtime          = "${var.runtime}"
-  description      = "${var.description} (stage: ${var.stage})"
-  tags             = "${var.tags}"
+  function_name                  = "${var.stage}_${var.name}"
+  filename                       = "${var.file}"
+  role                           = "${aws_iam_role.execution_lambda_role.arn}"
+  handler                        = "${var.handler}"
+  memory_size                    = "${var.memory_size}"
+  timeout                        = "${var.timeout}"
+  publish                        = "${var.publish}"
+  source_code_hash               = "${base64sha256(file("${var.file}"))}"
+  runtime                        = "${var.runtime}"
+  description                    = "${var.description} (stage: ${var.stage})"
+  kms_key_arn                    = "${var.kms_key_arn}"
+  tags                           = "${var.tags}"
+  reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
 
   tracing_config {
     mode = "${var.tracing_mode}"
@@ -98,16 +100,16 @@ resource "aws_lambda_alias" "lambda_alias" {
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
-  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
-  alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  metric_name               = "Throttles"
-  namespace                 = "AWS/Lambda"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  treat_missing_data        = "notBreaching"
+  alarm_description   = "${var.stage} ${var.name} Lambda Throttles"
+  alarm_name          = "${var.stage}_${var.name}_lambda_throttles"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
 
   dimensions {
     FunctionName = "${var.stage}_${var.name}"

--- a/modules/lambda-in-vpc/variables.tf
+++ b/modules/lambda-in-vpc/variables.tf
@@ -64,6 +64,11 @@ variable "security_group_ids" {
   default = []
 }
 
+variable "kms_key_arn" {
+  type    = "string"
+  default = ""
+}
+
 variable "tracing_mode" {
   type    = "string"
   default = "PassThrough"
@@ -72,4 +77,9 @@ variable "tracing_mode" {
 variable "tags" {
   type    = "map"
   default = {}
+}
+
+variable "reserved_concurrent_executions" {
+  type    = "string"
+  default = "-1"
 }

--- a/modules/lambda-with-s3/main.tf
+++ b/modules/lambda-with-s3/main.tf
@@ -46,18 +46,20 @@ resource "aws_iam_role_policy" "base_lambda_policy" {
 
 # Lambda
 resource "aws_lambda_function" "lambda" {
-  function_name    = "${var.stage}_${var.name}"
-  s3_bucket        = "${var.s3_bucket}"
-  s3_key           = "${var.s3_key}"
-  role             = "${aws_iam_role.execution_lambda_role.arn}"
-  handler          = "${var.handler}"
-  memory_size      = "${var.memory_size}"
-  timeout          = "${var.timeout}"
-  publish          = "${var.publish}"
-  source_code_hash = "${var.source_code_hash}"
-  runtime          = "${var.runtime}"
-  description      = "${var.description} (stage: ${var.stage})"
-  kms_key_arn      = "${var.kms_key_arn}"
+  function_name                  = "${var.stage}_${var.name}"
+  s3_bucket                      = "${var.s3_bucket}"
+  s3_key                         = "${var.s3_key}"
+  role                           = "${aws_iam_role.execution_lambda_role.arn}"
+  handler                        = "${var.handler}"
+  memory_size                    = "${var.memory_size}"
+  timeout                        = "${var.timeout}"
+  publish                        = "${var.publish}"
+  source_code_hash               = "${var.source_code_hash}"
+  runtime                        = "${var.runtime}"
+  description                    = "${var.description} (stage: ${var.stage})"
+  kms_key_arn                    = "${var.kms_key_arn}"
+  tags                           = "${var.tags}"
+  reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
 
   tracing_config {
     mode = "${var.tracing_mode}"
@@ -92,16 +94,16 @@ resource "aws_lambda_alias" "lambda_alias" {
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
-  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
-  alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  metric_name               = "Throttles"
-  namespace                 = "AWS/Lambda"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  treat_missing_data        = "notBreaching"
+  alarm_description   = "${var.stage} ${var.name} Lambda Throttles"
+  alarm_name          = "${var.stage}_${var.name}_lambda_throttles"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
 
   dimensions {
     FunctionName = "${var.stage}_${var.name}"

--- a/modules/lambda-with-s3/variables.tf
+++ b/modules/lambda-with-s3/variables.tf
@@ -66,3 +66,13 @@ variable "tracing_mode" {
   type    = "string"
   default = "PassThrough"
 }
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}
+
+variable "reserved_concurrent_executions" {
+  type    = "string"
+  default = "-1"
+}

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -45,18 +45,19 @@ resource "aws_iam_role_policy" "base_lambda_policy" {
 
 # Lambda
 resource "aws_lambda_function" "lambda" {
-  function_name    = "${var.stage}_${var.name}"
-  filename         = "${var.file}"
-  role             = "${aws_iam_role.execution_lambda_role.arn}"
-  handler          = "${var.handler}"
-  memory_size      = "${var.memory_size}"
-  timeout          = "${var.timeout}"
-  publish          = "${var.publish}"
-  source_code_hash = "${base64sha256(file("${var.file}"))}"
-  runtime          = "${var.runtime}"
-  description      = "${var.description} (stage: ${var.stage})"
-  kms_key_arn      = "${var.kms_key_arn}"
-  tags             = "${var.tags}"
+  function_name                  = "${var.stage}_${var.name}"
+  filename                       = "${var.file}"
+  role                           = "${aws_iam_role.execution_lambda_role.arn}"
+  handler                        = "${var.handler}"
+  memory_size                    = "${var.memory_size}"
+  timeout                        = "${var.timeout}"
+  publish                        = "${var.publish}"
+  source_code_hash               = "${base64sha256(file("${var.file}"))}"
+  runtime                        = "${var.runtime}"
+  description                    = "${var.description} (stage: ${var.stage})"
+  kms_key_arn                    = "${var.kms_key_arn}"
+  tags                           = "${var.tags}"
+  reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
 
   tracing_config {
     mode = "${var.tracing_mode}"
@@ -91,16 +92,16 @@ resource "aws_lambda_alias" "lambda_alias" {
 resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   count = "${var.enable_monitoring}" # Only create on certain stages.
 
-  alarm_description         = "${var.stage} ${var.name} Lambda Throttles"
-  alarm_name                = "${var.stage}_${var.name}_lambda_throttles"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "2"
-  metric_name               = "Throttles"
-  namespace                 = "AWS/Lambda"
-  period                    = "300"
-  statistic                 = "Sum"
-  threshold                 = "1"
-  treat_missing_data        = "notBreaching"
+  alarm_description   = "${var.stage} ${var.name} Lambda Throttles"
+  alarm_name          = "${var.stage}_${var.name}_lambda_throttles"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "Throttles"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  treat_missing_data  = "notBreaching"
 
   dimensions {
     FunctionName = "${var.stage}_${var.name}"

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -68,3 +68,8 @@ variable "tags" {
   type    = "map"
   default = {}
 }
+
+variable "reserved_concurrent_executions" {
+  type    = "string"
+  default = "-1"
+}


### PR DESCRIPTION
Also made sure all Lambda modules have the same feature set: some of them were missing either `kms_key_arn`, or `tags`.