### PR TITLE
Support SNS filter policy for SQS queues

### DIFF
--- a/modules/lambda-sqs-sns/README.md
+++ b/modules/lambda-sqs-sns/README.md
@@ -19,3 +19,5 @@ The SQS queue will instead consume messages from the SNS topic and then automati
 * `enable_monitoring` - Probably want to set this to `1` in a `prod` environment, so that you get alerted when something hits the DLQ.
 
 * `alarm_actions` - List of SNS topic ARNs and/or email addresses where the alarm should be sent to. If you want the alerts to be resolved automatically, you can also set `ok_actions`
+
+* `filter_policy` - Set filter policy on the SNS subscription, meaning only certain messages will be forwarded to the SQS queue (must be JSON).

--- a/modules/lambda-sqs-sns/main.tf
+++ b/modules/lambda-sqs-sns/main.tf
@@ -70,9 +70,10 @@ resource "aws_sqs_queue_policy" "queue_policy" {
 
 # hook up SNS --> SQS
 resource "aws_sns_topic_subscription" "sns_to_sqs" {
-  topic_arn = "${var.sns_arn}"
-  protocol  = "sqs"
-  endpoint  = "${aws_sqs_queue.queue.arn}"
+  topic_arn     = "${var.sns_arn}"
+  protocol      = "sqs"
+  endpoint      = "${aws_sqs_queue.queue.arn}"
+  filter_policy = "${var.filter_policy}"
 }
 
 # hook up SQS to the Lambda

--- a/modules/lambda-sqs-sns/variables.tf
+++ b/modules/lambda-sqs-sns/variables.tf
@@ -30,3 +30,8 @@ variable "ok_actions" {
   type    = "list"
   default = []
 }
+
+variable "filter_policy" {
+  type    = "string"
+  default = ""
+}


### PR DESCRIPTION
If `filter_policy` is specified, only certain messages will be passed onto the queue.

Relevant docs: https://docs.aws.amazon.com/sns/latest/dg/sns-subscription-filter-policies.html