### PR TITLE
Introduce throttle_threshold variable for Lambdas

### DIFF
--- a/modules/lambda-in-vpc-with-s3/main.tf
+++ b/modules/lambda-in-vpc-with-s3/main.tf
@@ -109,7 +109,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   namespace           = "AWS/Lambda"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "${var.throttle_threshold}"
   treat_missing_data  = "notBreaching"
 
   dimensions {

--- a/modules/lambda-in-vpc-with-s3/variables.tf
+++ b/modules/lambda-in-vpc-with-s3/variables.tf
@@ -86,3 +86,8 @@ variable "reserved_concurrent_executions" {
   type    = "string"
   default = "-1"
 }
+
+variable "throttle_threshold" {
+  type    = "string"
+  default = "1"
+}

--- a/modules/lambda-in-vpc/main.tf
+++ b/modules/lambda-in-vpc/main.tf
@@ -108,7 +108,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   namespace           = "AWS/Lambda"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "${var.throttle_threshold}"
   treat_missing_data  = "notBreaching"
 
   dimensions {

--- a/modules/lambda-in-vpc/variables.tf
+++ b/modules/lambda-in-vpc/variables.tf
@@ -83,3 +83,8 @@ variable "reserved_concurrent_executions" {
   type    = "string"
   default = "-1"
 }
+
+variable "throttle_threshold" {
+  type    = "string"
+  default = "1"
+}

--- a/modules/lambda-with-s3/main.tf
+++ b/modules/lambda-with-s3/main.tf
@@ -102,7 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   namespace           = "AWS/Lambda"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "${var.throttle_threshold}"
   treat_missing_data  = "notBreaching"
 
   dimensions {

--- a/modules/lambda-with-s3/variables.tf
+++ b/modules/lambda-with-s3/variables.tf
@@ -76,3 +76,8 @@ variable "reserved_concurrent_executions" {
   type    = "string"
   default = "-1"
 }
+
+variable "throttle_threshold" {
+  type    = "string"
+  default = "1"
+}

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   namespace           = "AWS/Lambda"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "${var.throttle_threshold}"
   treat_missing_data  = "notBreaching"
 
   dimensions {

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -73,3 +73,8 @@ variable "reserved_concurrent_executions" {
   type    = "string"
   default = "-1"
 }
+
+variable "throttle_threshold" {
+  type    = "string"
+  default = "1"
+}


### PR DESCRIPTION
Certain types of Lambda functions (primarily SQS triggered) should allow for some amount of throttling, and not alert immediately when such an event happens.