### PR TITLE
More outputs and set visibility timeout for the DLQ

### DIFF
--- a/modules/lambda-sqs-sns/main.tf
+++ b/modules/lambda-sqs-sns/main.tf
@@ -3,7 +3,7 @@
 # SQS dead letter queue
 resource "aws_sqs_queue" "dead_letter_queue" {
   name                       = "${var.stage}_${var.name}_dead_letter_queue"
-  visibility_timeout_seconds = 120
+  visibility_timeout_seconds = "${var.dlq_visibility_timeout_seconds}"
 
   tags {
     stage   = "${var.stage}"

--- a/modules/lambda-sqs-sns/outputs.tf
+++ b/modules/lambda-sqs-sns/outputs.tf
@@ -1,3 +1,15 @@
 output "sqs_arn" {
-    value = "${aws_sqs_queue.queue.arn}"
+  value = "${aws_sqs_queue.queue.arn}"
+}
+
+output "sqs_url" {
+  value = "${aws_sqs_queue.queue.id}"
+}
+
+output "dlq_arn" {
+  value = "${aws_sqs_queue.dead_letter_queue.arn}"
+}
+
+output "dlq_url" {
+  value = "${aws_sqs_queue.dead_letter_queue.id}"
 }

--- a/modules/lambda-sqs-sns/variables.tf
+++ b/modules/lambda-sqs-sns/variables.tf
@@ -9,8 +9,13 @@ variable "lambda_arn" {}
 # An SNS topic
 variable "sns_arn" {}
 
-# Timeout for messages in queue
+# Timeout for messages in the main queue
 variable "visibility_timeout_seconds" {
+  default = 120
+}
+
+# Timeout for messages in the dead-letter queue
+variable "dlq_visibility_timeout_seconds" {
   default = 120
 }
 


### PR DESCRIPTION
In many cases the queue URL is used instead of the ARN, so it can be pretty handy, plus having the ability to set the visibility timeout on the DLQ is also helpful if there are workers retrieving messages from it.