### PR TITLE
Create enabled flag for Regional WAF

### DIFF
--- a/modules/regional-waf/README.md
+++ b/modules/regional-waf/README.md
@@ -51,7 +51,7 @@ module "regional_waf" {
   rate_ip_throttle_limit = 2000
 
   # Default Value is 0.  This is an all or nothing setting.
-  # All conditions, rules, WebACLS, and WAF assoctiations
+  # All conditions, rules, WebACLS, and WAF associations
   # are governed by this value.
   #
   # When deploying to the test account, please use stage "test" and not your personal 

--- a/modules/regional-waf/README.md
+++ b/modules/regional-waf/README.md
@@ -49,5 +49,14 @@ module "regional_waf" {
 
   # Requests per 5 minutes.  Default in variables.tf = 5000.
   rate_ip_throttle_limit = 2000
+
+  # Default Value is 0.  This is an all or nothing setting.
+  # All conditions, rules, WebACLS, and WAF assoctiations
+  # are governed by this value.
+  #
+  # When deploying to the test account, please use stage "test" and not your personal 
+  # stage to avoid exhausting AWS resource limits for a WAF.
+
+  enabled = "${var.stage == "test" || var.stage == "development" || var.stage == "production" ? 1 : 0}"
 }
 ```

--- a/modules/regional-waf/variables.tf
+++ b/modules/regional-waf/variables.tf
@@ -69,3 +69,23 @@ variable "rate_ip_throttle_limit" {
     default = 5000
 }
 
+# Because COUNT still does not exist for modules.
+# this enables us to selectively deploy this resource to 
+# only to certain stages, ie.  test, vs dev, vs prod.
+# As of this PR there are still some very low per account
+# resource limits for rate based rules. 
+# https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
+# This is problematic in cases where you have test accounts with multiple projects
+# and multiple developers each running named instances that use this module.
+# 
+# BE AWARE THAT THIS IS A SINGLE SETTING FOR THE WHOLE MODULE.
+# THERE IS NO GRANULARITY TO THIS SETTING.
+#
+# Setting the default to 0 to ensure that deployment of the WAF
+# is an intentional decision.
+
+variable "enabled" {
+    type = "string"
+    default = 0
+}
+

--- a/modules/regional-waf/variables.tf
+++ b/modules/regional-waf/variables.tf
@@ -70,7 +70,7 @@ variable "rate_ip_throttle_limit" {
 }
 
 # Because COUNT still does not exist for modules.
-# this enables us to selectively deploy this resource to 
+# This enables us to selectively deploy this resource to 
 # only to certain stages, ie.  test, vs dev, vs prod.
 # As of this PR there are still some very low per account
 # resource limits for rate based rules. 


### PR DESCRIPTION
Adds "Enabled" Flag to Regional WAF.

Default value = 0 to ensure that WAF deployment is an intentional action.

This feature allows you to reference this module in your projects, while controlling the actual resource deployment based on a stage name.

Some WAF  resources have low per account limits.  This can be a particular issue in test accounts where multiple devs may have personal named stages.

Please note that this flag is an all or nothing feature.  If enabled = 0, NO resources are deployed.  
