### PR TITLE
adds sqs:SendMessage to lambdas with a DLQ

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -56,6 +56,16 @@ data "aws_iam_policy_document" "base_lambda_policy" {
 
     resources = ["*"]
   }
+
+  dynamic "statement" {
+    for_each = local.dead_letter_configs
+    content {
+      actions = ["sqs:SendMessage"]
+
+      resources = [local.dead_letter_configs_target_arn]
+    }
+  }
+
 }
 
 # Create Lambda role with AssumeRole policy.


### PR DESCRIPTION
This updates the lambda module so when the dead_letter_config variable
is specified an extra statement get's added to the lambda's policy that
allows `sqs:SendMessage` action against the dlq arn.