### PR TITLE
Add tags variable to lambda-sqs-sns module

### DIFF
--- a/modules/lambda-sqs-sns/variables.tf
+++ b/modules/lambda-sqs-sns/variables.tf
@@ -65,11 +65,16 @@ variable "alarm_threshold" {
 }
 
 variable "alarm_name" {
-  type = string
+  type    = string
   default = ""
 }
 
 variable "alarm_description" {
-  type = string
+  type    = string
   default = ""
+}
+
+variable "tags" {
+  type    = map
+  default = {}
 }


### PR DESCRIPTION
Allow `tags` map to be passed to lambda-sns-sqs module while preserving existing default behavior.