### PR TITLE
Allow extra variables to be passed into the Swagger template

### DIFF
--- a/modules/apigateway/main.tf
+++ b/modules/apigateway/main.tf
@@ -47,7 +47,7 @@ resource "aws_iam_role_policy" "lambda_invoke_policy" {
 data "template_file" "swagger_file" {
   template = var.swagger_template
 
-  vars = {
+  vars = merge({
     authorizer_type            = var.authorizer_type
     authorizer_arn             = var.authorizer_arn
     authorizer_header          = var.authorizer_header
@@ -60,7 +60,7 @@ data "template_file" "swagger_file" {
     stage                      = var.stage != "prod" ? format("%s-", var.stage) : ""
     api_name                   = "${var.stage}_${var.name}"
     description                = "${var.description} (stage: ${var.stage})"
-  }
+  }, var.extra_template_vars)
 }
 
 resource "aws_api_gateway_rest_api" "api" {

--- a/modules/apigateway/variables.tf
+++ b/modules/apigateway/variables.tf
@@ -58,6 +58,11 @@ variable "lambda_arn" {
   default = ""
 }
 
+variable "extra_template_vars" {
+  type    = map(string)
+  default = {}
+}
+
 variable "name" {
 }
 


### PR DESCRIPTION
This would provide more flexibility, for example when wanting to route different paths to different Lambda functions. Currently everything can only be routed to the same Lambda function denoted by `lambda_arn`.